### PR TITLE
updated sticky note auth for admin/approver vs owner and guest

### DIFF
--- a/groupProjectBackend/groupProjectBackend/settings.py
+++ b/groupProjectBackend/groupProjectBackend/settings.py
@@ -29,7 +29,7 @@ SECRET_KEY = os.environ.get(
 )
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get('DJANGO_DEBUG') != 'True'
+DEBUG = os.environ.get('DJANGO_DEBUG') != 'False'
 
 ALLOWED_HOSTS = ['*']
 CORS_ALLOW_ALL_ORIGINS = True

--- a/groupProjectBackend/winwall/serializers.py
+++ b/groupProjectBackend/winwall/serializers.py
@@ -56,6 +56,30 @@ class StickyNoteSerializer(serializers.Serializer):
 
 
 class StickyNoteDetailSerializer(StickyNoteSerializer):
+    sticky_status = serializers.SerializerMethodField()
+
+    def get_sticky_status(self, obj):
+        is_live =  self.get_win_wall_live(obj)
+        if is_live == 'Live':
+            return 'Live'
+        elif is_live == 'Closed' and obj.is_approved == False and obj.is_archived == False:
+            return 'Unapproved'
+        elif obj.is_approved == True and is_live == 'Closed' and obj.is_archived == False:
+            return 'Approved'
+        elif obj.is_approved == True and obj.is_archived == True:
+            return 'Archived'
+        elif obj.is_approved == True and obj.is_archived == False:
+            return 'Approved'
+        elif obj.is_approved == False and obj.is_archived == False:
+            return 'Unapproved'
+
+
+    def update(self, instance, validated_data):
+        instance.win_comment = validated_data.get('win_comment', instance.win_comment)
+        instance.save()
+        return instance 
+
+class AdminStickyNoteDetailSerializer(StickyNoteSerializer):
     is_approved = serializers.BooleanField(required=False)
     is_archived = serializers.BooleanField(required=False)
     sticky_status = serializers.SerializerMethodField()

--- a/groupProjectBackend/winwall/urls.py
+++ b/groupProjectBackend/winwall/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     # general users & admins view
     path('sticky-notes/', views.StickyNoteList.as_view()),
     # admin only view
+    path('admin-sticky-note/<int:pk>/', views.AdminStickyNoteDetail.as_view()),
     path('sticky-note/<int:pk>/', views.StickyNoteDetail.as_view()),
     # in progress - bulk updates of SN via winwall 
     path('win-wall-notes/<int:pk>/', views.WinWallBulkUpdate.as_view()),


### PR DESCRIPTION
![bitmoji](https://sdk.bitmoji.com/render/panel/6d15121b-9336-4ae6-9a44-d95433e10e35-1718c37c-5bac-4fa1-a081-40ffcb1da175-v1.png?transparent=1&palette=1&width=246)
updated sticky note auth

owners can edit their own sticky note comment only

guests can only view notes

super user, admin and approvers can edit, approve and archive

-note: will need to update front end for apply appropriate auth restrictions 

<img width="538" alt="image" src="https://user-images.githubusercontent.com/94447107/170830073-d534df60-14e2-421c-b7ab-9d96b038c84d.png">
<img width="554" alt="image" src="https://user-images.githubusercontent.com/94447107/170830130-7567c31d-30e8-40e3-8f41-324dea00c7b8.png">

